### PR TITLE
feat: export default branch for orgs repos endpoint

### DIFF
--- a/routes/_health.ts
+++ b/routes/_health.ts
@@ -1,4 +1,4 @@
-export default eventHandler(async () => {
+export default eventHandler(() => {
   // const runtimeConfig = useRuntimeConfig();
   // const res = await $fetch.raw("/meta", {
   //   baseURL: "https://api.github.com",

--- a/routes/orgs/[owner]/repos.ts
+++ b/routes/orgs/[owner]/repos.ts
@@ -19,6 +19,7 @@ export default eventHandler(async (event) => {
         stars: rawRepo.stargazers_count,
         watchers: rawRepo.watchers,
         forks: rawRepo.forks,
+        defaultBranch: rawRepo.default_branch,
       },
   );
 


### PR DESCRIPTION
Hello,

In the same way the default branch is exported for a single repo, having this info for all repos from an orgs could be useful.

_related to UnJS Relations where I need to know the default branch when I fetch every repos from an organization_